### PR TITLE
Add support for python3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_ARCHS: ${{ matrix.plat.arch }}
 
           CIBW_ENVIRONMENT_MACOS: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "scikit_build_core.build"
 [tool.scikit-build]
 cmake.define = {"GREEN_PYTHON"="ON"}
 wheel.packages = ["python/green_ac"]
-cmake.verbose = true
+build.verbose = true
 
 [project]
 name = "green-ac"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
   { name="Sergei Iskakov", email="siskakov@umich.edu" },
 ]


### PR DESCRIPTION
PR has minor fix in `pyproject.toml` to allow support for python3.13; this is accompanied with a version update