### PR TITLE
Support Python 3.14 and release 0.2.8

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
           CIBW_ARCHS: ${{ matrix.plat.arch }}
 
           CIBW_ENVIRONMENT_MACOS: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,13 @@ build.verbose = true
 
 [project]
 name = "green-ac"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
   { name="Sergei Iskakov", email="siskakov@umich.edu" },
+]
+
+maintainers = [
+  { name="Gaurav Harsha", email="gharsha@umich.edu" },
 ]
 
 dependencies = ["numpy", "h5py", "scipy"]


### PR DESCRIPTION
## Summary
- Build **cp314** wheels: add `cp314-*` to `CIBW_BUILD` and bump `pypa/cibuildwheel` to `v3.4.1` (first line shipping CPython 3.14 as a stable default target; v2.21.3 cannot build cp314).
- Bump version `0.2.7` → `0.2.8` for the next release.
- Add a `maintainers` field (Gaurav Harsha) alongside the existing `authors` (Sergei Iskakov), reflecting current maintainership.

## Motivation
Part of extending the Green ecosystem to Python 3.14. green-mbtools is adding 3.14 support and depends (transitively) on green-ac, so green-ac needs cp314 wheels on PyPI for the 3.14 stack to install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)